### PR TITLE
Realistic solution for issue #2. You can set color to this component.

### DIFF
--- a/colorpicker/colorpicker.qml
+++ b/colorpicker/colorpicker.qml
@@ -6,10 +6,7 @@ import "content"
 
 Rectangle {
     id: colorPicker
-    property color colorValue: paletteMode ?
-                                   _rgb(paletts.paletts_color, alphaSlider.value) :
-                                   _hsla(hueSlider.value, sbPicker.saturation,
-                                    sbPicker.brightness, alphaSlider.value)
+    property color colorValue: "transparent"
     property bool enableAlphaChannel: true
     property bool enableDetails: true
     property int colorHandleRadius : 8
@@ -17,6 +14,14 @@ Rectangle {
     property bool enablePaletteMode : false
     property string switchToColorPickerString: "Palette..."
     property string switchToPalleteString: "Color Picker..."
+
+    property color _changingColorValue : paletteMode ?
+                                   _rgb(paletts.paletts_color, alphaSlider.value) :
+                                   _hsla(hueSlider.value, sbPicker.saturation,
+                                    sbPicker.brightness, alphaSlider.value)
+    on_ChangingColorValueChanged: {
+        colorValue = _changingColorValue
+    }
 
     signal colorChanged(color changedColor)
 
@@ -256,5 +261,20 @@ Rectangle {
     //  extracts integer color channel value [0..255] from color value
     function _getChannelStr(clr, channelIdx) {
         return parseInt(clr.toString().substr(channelIdx*2 + 1, 2), 16)
+    }
+
+    // set color from outside
+    function setColor(color) {
+
+        // color object
+        var c = Qt.tint(color, "transparent")
+
+        console.debug('set_color is called with:'+c)
+
+        // set alpha
+        alphaSlider.setValue(c.a)
+
+        // set rgb. Now it's insufficient to update hue related component.
+        colorPicker.colorValue = c
     }
 }

--- a/colorpicker/content/ColorSlider.qml
+++ b/colorpicker/content/ColorSlider.qml
@@ -37,8 +37,12 @@ Item {
 
     onVisibleChanged: {
         if(visible) {
-            pickerCursor.y = -cursorHeight*0.5
+            pickerCursor.y = 0
         }
+    }
+
+    function setValue(val) {
+        pickerCursor.y = height * (1 - val)
     }
 }
 

--- a/test/main.qml
+++ b/test/main.qml
@@ -9,6 +9,7 @@ Window {
     width: 400
     height: 350
     title: qsTr("Hello Colorpicker")
+    property color captured_color: "transparent"
 
     GridLayout {
         anchors.top: parent.top
@@ -41,17 +42,32 @@ Window {
                 my_picker.enableDetails = checked
             }
         }
-        Row {
-            Layout.topMargin: 10
-            Button {
-                width: 40
-                height: 20
-                background: Rectangle {
-                    color: my_picker.colorValue
+        Column {
+            Row {
+                Layout.topMargin: 10
+                Button {
+                    width: 40
+                    height: 20
+                    background: Rectangle {
+                        color: my_picker.colorValue
+                    }
+                }
+                Label {
+                    text: "Defined Color"
                 }
             }
-            Label {
-                text: "Defined Color"
+            Row {
+                Layout.topMargin: 10
+                Button {
+                    width: 40
+                    height: 20
+                    background: Rectangle {
+                        color: captured_color
+                    }
+                }
+                Label {
+                    text: "Captured Color"
+                }
             }
         }
         CheckBox {
@@ -70,10 +86,20 @@ Window {
                 my_picker.enablePaletteMode = checked
             }
         }
-        Button {
-            text:"alfa reset"
-            onClicked: {
-                my_picker.visible = ! my_picker.visible
+        Column {
+            Button {
+                height: 20
+                text:"Capture color"
+                onClicked: {
+                    captured_color = my_picker.colorValue
+                }
+            }
+            Button {
+                height: 20
+                text:"Set captured color"
+                onClicked: {
+                    my_picker.setColor(captured_color)
+                }
             }
         }
     }


### PR DESCRIPTION
** Realistic solution for issue #2. You can set color to this component.
[Related Issue](https://github.com/rshest/qml-colorpicker/issues/2)

fix : invalid position when it's back from palette mode
enhance : test panel for initial color test
enhance : slider value can be set from outside

Note : Hue slider and hue picker are not update. It's difficult.

** Test Procedures (main.qml): 
1. Choose a color. Both Palette and Picker mode are ok.
2. Select "Capture color" button.
3. Choose the other color.
4. Select "Set captured color" button.
5. You can see updated things :
    * full color string
    * alpha slider value position
    * color panel color

   Not updated things as follows:
   * hue picker
   * hue slider

