### PR TITLE
More control of sizes

### DIFF
--- a/colorpicker/Colorpicker.qml
+++ b/colorpicker/Colorpicker.qml
@@ -25,7 +25,8 @@ Rectangle {
 
     signal colorChanged(color changedColor)
 
-    width: 400; height: 200
+    implicitWidth: picker.implicitWidth
+    implicitHeight: palette_switch.implicitHeight + picker.implicitHeight
     color: "#3C3C3C"
     clip: true
 

--- a/colorpicker/Colorpicker.qml
+++ b/colorpicker/Colorpicker.qml
@@ -61,12 +61,11 @@ Rectangle {
 
             Layout.fillWidth: true
             Layout.fillHeight: true
+            Layout.minimumWidth: paletts.implicitWidth
+            Layout.minimumHeight: paletts.implicitHeight
 
             SBPicker {
                 id: sbPicker
-
-                height: parent.implicitHeight
-                width: parent.implicitWidth
 
                 hueColor: {
                     var v = 1.0-hueSlider.value

--- a/colorpicker/Colorpicker.qml
+++ b/colorpicker/Colorpicker.qml
@@ -27,6 +27,7 @@ Rectangle {
 
     width: 400; height: 200
     color: "#3C3C3C"
+    clip: true
 
     Text {
         id: palette_switch
@@ -42,8 +43,6 @@ Rectangle {
         anchors.rightMargin: colorHandleRadius
         linkColor: "white"
     }
-
-    clip: true
 
     RowLayout {
         id: picker

--- a/colorpicker/content/Palettes.qml
+++ b/colorpicker/content/Palettes.qml
@@ -5,6 +5,9 @@ Item {
     id: item
     property color paletts_color : "transparent"
 
+    implicitHeight: grid.height
+    implicitWidth: grid.width
+
     Grid {
         id: grid
         rows: 5


### PR DESCRIPTION
This PR:
* forces minimum size for SwipeView. It prevents SwipeView from becoming smaller than Palletes item which causes visual issues.
* sets implicitWidth and implicitHeight based on size of internal items which gives hints for layouts and positioners Colorpicker is being put into.